### PR TITLE
Limit product creation and add namespace to Program.cs

### DIFF
--- a/src/Api.Produto/Controllers/ProductController.cs
+++ b/src/Api.Produto/Controllers/ProductController.cs
@@ -79,6 +79,9 @@ namespace Api.Controllers
         {
             Faker faker = new Faker("pt_BR");
 
+            const int MaxProducts = 1000;
+            total = Math.Clamp(total, 1, MaxProducts);
+
             var produtos = new List<CreateProductCommand>();
 
             for (int i = 0; i < total; i++)

--- a/src/Product.Consumer/Program.cs
+++ b/src/Product.Consumer/Program.cs
@@ -2,6 +2,8 @@
 using Product.Consumer.Configurations;
 using Serilog;
 
+namespace Product.Consumer;
+
 class Program
 {
     public static async Task Main(string[] args)


### PR DESCRIPTION
Added a maximum limit of 1000 products in `CriarListaProduto` method of `ProductController.cs` using `Math.Clamp` to ensure the `total` parameter is within bounds. Introduced `MaxProducts` constant. Added `Product.Consumer` namespace to `Program.cs` for better organization and to avoid naming conflicts.