### PR TITLE
Update configurations and add load testing script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 *.txt
+*.env
 
 # Build results
 [Dd]ebug/

--- a/docker/configs/alert.rules.yml
+++ b/docker/configs/alert.rules.yml
@@ -10,12 +10,14 @@ groups:
       summary: "Muitas consultas"
       description: "O {{ $labels.instance }} Gateway API received to many requests ({{ $value }})"
 
-
+ # Este alerta monitora a taxa de requisições recebidas pela API "Product.Api" em cada instância.
+ # Se qualquer instância receber, em média, mais de 10 requisições por segundo durante pelo menos 30 segundos, o alerta será disparado.
+ # Isso pode indicar uma sobrecarga, ataque ou aumento inesperado de uso, e o Alertmanager pode notificar a equipe responsável com as informações configuradas
 - name: ProductAPI
   rules:
   - alert: ProductApiAlert - To many requests
     expr: sum(rate(http_server_request_duration_seconds_count{appName="Product.Api"}[1m])) by (instance) > 10
-    for: 30s # perido de tempo para disparar o alerta
+    for: 30s # O alerta só será disparado se a condição acima se mantiver verdadeira por pelo menos 30
     labels:
       team: casoft-store-product # serve para o alertmanager rotear o alerta, usado no arquivo alertmanager.yml
     annotations:
@@ -27,7 +29,7 @@ groups:
   rules:
   - alert: BasketApiAlert - To many requests
     expr: sum(rate(http_server_request_duration_seconds_count{appName="Basket.Api"}[1m])) by (instance) > 10
-    for: 30s # perido de tempo para disparar o alerta
+    for: 30s # O alerta só será disparado se a condição acima se mantiver verdadeira por pelo menos 30
     labels:
       team: casoft-store-basket # serve para o alertmanager rotear o alerta, usado no arquivo alertmanager.yml
     annotations:
@@ -38,7 +40,7 @@ groups:
   rules:
   - alert: BillingApiAlert - To many requests
     expr: sum(rate(http_server_request_duration_seconds_count{appName="Billing.Api"}[1m])) by (instance) > 10
-    for: 30s # perido de tempo para disparar o alerta
+    for: 30s # O alerta só será disparado se a condição acima se mantiver verdadeira por pelo menos 30
     labels:
       team: casoft-store-billing # serve para o alertmanager rotear o alerta, usado no arquivo alertmanager.yml
     annotations:
@@ -49,7 +51,7 @@ groups:
   rules:
   - alert: CatalogApiAlert - To many requests
     expr: sum(rate(http_server_request_duration_seconds_count{appName="Catalog.Api"}[1m])) by (instance) > 10
-    for: 30s # perido de tempo para disparar o alerta
+    for: 30s # O alerta só será disparado se a condição acima se mantiver verdadeira por pelo menos 30
     labels:
       team: casoft-store-catalog # serve para o alertmanager rotear o alerta, usado no arquivo alertmanager.yml
     annotations:
@@ -60,7 +62,7 @@ groups:
   rules:
   - alert: DiscountApiAlert - To many requests
     expr: sum(rate(http_server_request_duration_seconds_count{appName="Discount.Api"}[1m])) by (instance) > 10
-    for: 30s # perido de tempo para disparar o alerta
+    for: 30s # O alerta só será disparado se a condição acima se mantiver verdadeira por pelo menos 30
     labels:
       team: casoft-discount-api # serve para o alertmanager rotear o alerta, usado no arquivo alertmanager.yml
     annotations:
@@ -71,7 +73,7 @@ groups:
   rules:
   - alert: OrderApiAlert - To many requests
     expr: sum(rate(http_server_request_duration_seconds_count{appName="Order.Api"}[1m])) by (instance) > 10
-    for: 30s # perido de tempo para disparar o alerta
+    for: 30s # O alerta só será disparado se a condição acima se mantiver verdadeira por pelo menos 30
     labels:
       team: casoft-order-api # serve para o alertmanager rotear o alerta, usado no arquivo alertmanager.yml
     annotations:
@@ -82,7 +84,7 @@ groups:
   rules:
   - alert: AuthApiAlert - To many requests
     expr: sum(rate(http_server_request_duration_seconds_count{appName="Auth.Api"}[1m])) by (instance) > 10
-    for: 30s # perido de tempo para disparar o alerta
+    for: 30s # O alerta só será disparado se a condição acima se mantiver verdadeira por pelo menos 30
     labels:
       team: casoft-api-auth # serve para o alertmanager rotear o alerta, usado no arquivo alertmanager.yml
     annotations:

--- a/docker/configs/alertmanager.yml
+++ b/docker/configs/alertmanager.yml
@@ -1,16 +1,16 @@
 route:
-  receiver: 'Default'
-  group_by: ['alertname', 'team', 'instance']
-  group_wait: 30s
-  group_interval: 30s
-  repeat_interval: 30s
+  receiver: 'Default' # O receptor padrão para alertas que não casam com nenhuma sub-rota.
+  group_by: ['alertname', 'team', 'instance'] # Agrupa alertas com os mesmos valores dessas labels em uma única notificação.
+  group_wait: 30s # Espera até 30 segundos antes de enviar o primeiro alerta de um novo grupo (útil para agrupar alertas que chegam juntos).
+  group_interval: 30s # Tempo mínimo entre notificações para o mesmo grupo de alertas.
+  repeat_interval: 30s # intervalo para reenviar alertas não resolvidos.
   routes:
 
     - receiver: AlertGatewayApi
-      group_wait: 10s
+      group_wait: 10s # Espera só 10 segundos antes de enviar o alerta para esse grupo.
       match:
-        team: "casoft-api-gateway"
-      continue: true    
+        team: "casoft-api-gateway" # Se o alerta tiver a label team: "casoft-api-gateway", ele será enviado para o receiver AlertGatewayApi.
+      continue: true    # Depois de processar essa rota, o Alertmanager continua avaliando as próximas rotas (útil se você quiser enviar o mesmo alerta para múltiplos receivers).
 
     - receiver: AlertApiAuth
       group_wait: 10s
@@ -54,13 +54,13 @@ route:
         team: "casoft-store-product"
       continue: true
 
-    - receiver: AlertProductApi2
+    - receiver: AlertProductApiHigh
       group_wait: 10s
       match:
         team: "casoft-store-product"
       continue: true
 
-    - receiver: AlertProductApi3
+    - receiver: AlertProductApiLow
       group_wait: 10s
       match:
         team: "casoft-store-product"
@@ -75,7 +75,7 @@ route:
 receivers:
   - name: Default
     webhook_configs:
-      - url: 'http://alertview:8181/webhook'
+      - url: 'http://alertview:8181/webhook' # Envia os alertas para o endpoint HTTP http://alertview:8181/webhook.
 
   - name: AlertGatewayApi
     webhook_configs:
@@ -108,14 +108,22 @@ receivers:
   - name: AlertProductApi
     webhook_configs:
       - send_resolved: true
-        url: 'http://alertview:8181/webhook' 
+        url: 'http://alertview:8181/webhook' # Também envia para o mesmo endpoint, mas com send_resolved: true, ou seja, envia notificações tanto quando o alerta dispara quanto quando ele é resolvido.
 
-  - name: 'AlertProductApi2'
+  - name: 'AlertProductApiHigh'
     webhook_configs:
       - send_resolved: true
-        url: 'http://promteams:2000/high_priority_channel'
+        url: 'http://promteams:2000/high_priority_channel' # Envia alertas para um canal de alta prioridade em http://promteams:2000/high_priority_channel.
 
-  - name: 'AlertProductApi3'
+  - name: 'AlertProductApiLow'
     webhook_configs:
       - send_resolved: true
         url: 'http://promteams:2000/low_priority_channel'                                                     
+        
+
+# Fluxo resumido:
+# O Alertmanager recebe alertas do Prometheus.
+# Ele agrupa os alertas conforme group_by.
+# Se o alerta tiver team: "casoft-api-gateway", vai para o receiver AlertGatewayApi.
+# Caso não case com nenhuma sub-rota, vai para o receiver Default.
+# Os receivers definem para onde os alertas serão enviados (webhooks ou outros canais).        

--- a/docker/configs/config.alloy
+++ b/docker/configs/config.alloy
@@ -1,142 +1,38 @@
-logging {
-  level  = "info"
-  format = "logfmt"
-}
-
 otelcol.receiver.otlp "default" {
-	// https://grafana.com/docs/alloy/latest/reference/components/otelcol.receiver.otlp/
+  http {
+    endpoint = "0.0.0.0:4318"
+    
+  }
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
 
-	// configures the default grpc endpoint "0.0.0.0:4317"
-	grpc { }
-	// configures the default http/protobuf endpoint "0.0.0.0:4318"
-	http { }
-
-	output {
-		metrics = [otelcol.processor.resourcedetection.default.input]
-		logs    = [otelcol.processor.resourcedetection.default.input]
-		traces  = [otelcol.processor.resourcedetection.default.input]
-	}
+  output {
+    metrics = [otelcol.exporter.otlphttp.metrics.input]
+    logs    = [otelcol.exporter.otlphttp.logs.input]
+    traces = [otelcol.exporter.otlphttp.traces.input]
+  }
 }
 
-otelcol.processor.resourcedetection "default" {
-	// https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.resourcedetection/
-	detectors = ["env", "docker", "system"]
+otelcol.exporter.otlphttp "logs" {
+  client {
+    endpoint = "http://loki:3100/otlp"
+  }
 
-	system {
-		hostname_sources = ["os"]
-	}
-
-	output {
-		metrics = [otelcol.processor.transform.drop_unneeded_resource_attributes.input]
-		logs    = [otelcol.processor.transform.drop_unneeded_resource_attributes.input]
-		traces  = [otelcol.processor.transform.drop_unneeded_resource_attributes.input]
-	}
 }
 
-otelcol.processor.transform "drop_unneeded_resource_attributes" {
-	// https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.transform/
-	error_mode = "ignore"
-
-	trace_statements {
-		context    = "resource"
-		statements = [
-			"delete_key(attributes, \"k8s.pod.start_time\")",
-			"delete_key(attributes, \"os.description\")",
-			"delete_key(attributes, \"os.type\")",
-			"delete_key(attributes, \"process.command_args\")",
-			"delete_key(attributes, \"process.executable.path\")",
-			"delete_key(attributes, \"process.pid\")",
-			"delete_key(attributes, \"process.runtime.description\")",
-			"delete_key(attributes, \"process.runtime.name\")",
-			"delete_key(attributes, \"process.runtime.version\")",
-		]
-	}
-
-	metric_statements {
-		context    = "resource"
-		statements = [
-			"delete_key(attributes, \"k8s.pod.start_time\")",
-			"delete_key(attributes, \"os.description\")",
-			"delete_key(attributes, \"os.type\")",
-			"delete_key(attributes, \"process.command_args\")",
-			"delete_key(attributes, \"process.executable.path\")",
-			"delete_key(attributes, \"process.pid\")",
-			"delete_key(attributes, \"process.runtime.description\")",
-			"delete_key(attributes, \"process.runtime.name\")",
-			"delete_key(attributes, \"process.runtime.version\")",
-		]
-	}
-
-	log_statements {
-		context    = "resource"
-		statements = [
-			"delete_key(attributes, \"k8s.pod.start_time\")",
-			"delete_key(attributes, \"os.description\")",
-			"delete_key(attributes, \"os.type\")",
-			"delete_key(attributes, \"process.command_args\")",
-			"delete_key(attributes, \"process.executable.path\")",
-			"delete_key(attributes, \"process.pid\")",
-			"delete_key(attributes, \"process.runtime.description\")",
-			"delete_key(attributes, \"process.runtime.name\")",
-			"delete_key(attributes, \"process.runtime.version\")",
-		]
-	}
-
-	output {
-		metrics = [otelcol.processor.transform.add_resource_attributes_as_metric_attributes.input]
-		logs    = [otelcol.processor.batch.default.input]
-		traces  = [
-			otelcol.processor.batch.default.input,
-			otelcol.connector.host_info.default.input,
-		]
-	}
+otelcol.exporter.otlphttp "metrics" {
+  client {
+    endpoint = "http://prometheus:9090/api/v1/otlp"
+  }
 }
 
-otelcol.connector.host_info "default" {
-	// https://grafana.com/docs/alloy/latest/reference/components/otelcol.connector.host_info/
-	host_identifiers = ["host.name"]
-
-	output {
-		metrics = [otelcol.processor.batch.default.input]
-	}
+otelcol.exporter.otlphttp "traces" {
+    client {
+        endpoint = "http://tempo:4318"
+    }
 }
 
-otelcol.processor.transform "add_resource_attributes_as_metric_attributes" {
-	// https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.transform/
-	error_mode = "ignore"
-
-	metric_statements {
-		context    = "datapoint"
-		statements = [
-			"set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
-			"set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
-		]
-	}
-
-	output {
-		metrics = [otelcol.processor.batch.default.input]
-	}
-}
-
-otelcol.processor.batch "default" {
-	// https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.batch/
-	output {
-		metrics = [otelcol.exporter.otlphttp.grafana_cloud.input]
-		logs    = [otelcol.exporter.otlphttp.grafana_cloud.input]
-		traces  = [otelcol.exporter.otlphttp.grafana_cloud.input]
-	}
-}
-
-otelcol.exporter.otlphttp "grafana_cloud" {
-	// https://grafana.com/docs/alloy/latest/reference/components/otelcol.exporter.otlphttp/
-	client {
-		endpoint = env("GRAFANA_CLOUD_OTLP_ENDPOINT")
-		auth     = otelcol.auth.basic.grafana_cloud.handler
-	}
-}
-
-otelcol.auth.basic "grafana_cloud" {
-	// https://grafana.com/docs/alloy/latest/reference/components/otelcol.auth.basic/
-	username = env("GRAFANA_CLOUD_INSTANCE_ID")
-	password = env("GRAFANA_CLOUD_API_KEY")
+livedebugging {
+  enabled = true
 }

--- a/docker/configs/loki.yaml
+++ b/docker/configs/loki.yaml
@@ -1,11 +1,11 @@
-auth_enabled: false
+auth_enabled: false # Desativa autenticação no Loki. Qualquer um pode acessar as APIs e endpoints do Loki sem precisar de autenticação.
 
 server:
   http_listen_port: 3100
-  http_server_read_timeout: 20m
-  http_server_write_timeout: 20m
-  grpc_server_max_recv_msg_size: 104857600
-  grpc_server_max_send_msg_size: 104857600
+  http_server_read_timeout: 20m # Tempo máximo que o servidor vai esperar para ler uma requisição (20 minutos).
+  http_server_write_timeout: 20m # Tempo máximo que o servidor vai esperar para escrever uma resposta (20 minutos).
+  grpc_server_max_recv_msg_size: 104857600 # Tamanho máximo de mensagem recebida via gRPC (100 MB).
+  grpc_server_max_send_msg_size: 104857600 # Tamanho máximo de mensagem enviada via gRPC (100 MB).
 #  cors:
 #    allowed_origins: ["*"]  # You can replace "*" with the specific domains you want to allow
 #    allowed_methods: ["GET", "POST", "OPTIONS", "DELETE", "PUT"]
@@ -14,28 +14,28 @@ server:
 #    allow_credentials: false
 
 common:
-  path_prefix: /loki
+  path_prefix: /loki # Define o prefixo de caminho onde os dados e arquivos do Loki serão armazenados.
   storage:
     filesystem:
-      chunks_directory: /loki/chunks
-      rules_directory: /loki/rules
-  replication_factor: 1
+      chunks_directory: /loki/chunks # Onde os arquivos de chunks (blocos de logs) serão salvos no disco.
+      rules_directory: /loki/rules # Onde as regras de alertas do Loki serão salvas.
+  replication_factor: 1 # Define o fator de replicação dos dados. Com valor 1, não há replicação (apenas uma cópia dos dados).
   ring:
     kvstore:
-      store: inmemory
+      store: inmemory # O anel de distribuição de dados (ring) usa armazenamento em memória para manter o estado. Isso é comum em ambientes de teste ou instâncias únicas (não recomendado para produção com alta disponibilidade).
 
 schema_config:
   configs:
-    - from: 2020-10-24
-      store: boltdb-shipper
-      object_store: filesystem
-      schema: v11
+    - from: 2020-10-24 # A partir dessa data, esta configuração de schema entra em vigor.
+      store: boltdb-shipper # O Loki usa o boltdb-shipper para armazenar índices localmente e sincronizá-los com o armazenamento de objetos.
+      object_store: filesystem # O armazenamento de objetos dos logs será no próprio sistema de arquivos, não em nuvem.
+      schema: v11 # Versão do schema usado para organizar os dados.
       index:
-        prefix: index_
-        period: 24h
+        prefix: index_ # Prefixo dos arquivos de índice.
+        period: 24h # Cria um novo índice a cada 24 horas.
 
 ruler:
-  alertmanager_url: http://localhost:9093
+  alertmanager_url: http://localhost:9093 # Endereço do Alertmanager para onde o Loki enviará alertas configurados nas regras.
 
 # By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
 # analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/

--- a/docker/configs/otel-collector-config.yaml
+++ b/docker/configs/otel-collector-config.yaml
@@ -1,36 +1,47 @@
+# receivers são componentes que recebem dados de telemetria (traces, metrics, logs) de aplicações ou agentes
 receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: 0.0.0.0:4317 # escuta na porta 4317 para receber dados via gRPC
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: 0.0.0.0:4318 # escuta na porta 4318 para receber dados via HTTP.
 
+# adicionam funcionalidades extras ao collector.
 extensions:
-  health_check: {}
+  health_check: {} #  habilita um endpoint de health check (verificação de saúde) para saber se o collector está rodando corretamente.
 
+# exporters enviam dados processados para outros sistemas.
 exporters:
   otlp:
-    endpoint: jaeger:4317
+    endpoint: jaeger:4317 # envia dados OTLP para outro sistema, neste caso, para um serviço chamado jaeger na porta 4317 (provavelmente um Jaeger Collector rodando em outro container).
     tls:
-      insecure: true
+      insecure: true #  não usa TLS, conexão insegura (útil para ambientes de teste).
   prometheus:
-    endpoint: "0.0.0.0:8889"
+    endpoint: "0.0.0.0:8889" # expõe métricas no endpoint HTTP 0.0.0.0:8889 para serem coletadas pelo Prometheus.
     resource_to_telemetry_conversion:
-      enabled: true
+      enabled: true # converte atributos de recursos em labels de métricas.
   debug:
 #    verbosity: detailed
 
+# processors manipulam ou processam dados antes de exportá-los
 processors:
-  batch:
+  batch: # batch agrupa dados em lotes antes de exportar, melhorando desempenho e eficiência.
 
 service:
   pipelines:
     traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlp]
+      receivers: [otlp] # Recebe traces via OTLP.
+      processors: [batch] # Processa com batch.
+      exporters: [otlp] # Exporta para o Jaeger (otlp exporter).
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug, prometheus]
+      exporters: [debug, prometheus] # Exporta para o Prometheus e para o debug (log).
+      
+      
+# Resumo:
+# Seu collector recebe traces e métricas via OTLP (gRPC e HTTP).
+# Traces são enviados para o Jaeger.
+# Métricas são expostas para Prometheus e também logadas para debug.
+# Usa processamento em lote para eficiência.      

--- a/docker/configs/prometheus.yml
+++ b/docker/configs/prometheus.yml
@@ -1,21 +1,21 @@
 global:
-  scrape_interval: 15s
-  scrape_timeout: 10s
-  evaluation_interval: 15s
+  scrape_interval: 15s # Prometheus coleta (scrape) as métricas dos targets a cada 15 segundos (padrão global).
+  scrape_timeout: 10s # Se a coleta demorar mais de 10 segundos, ela é cancelada.
+  evaluation_interval: 15s # As regras (alertas, gravações) são avaliadas a cada 15 segundos.
 
 rule_files:
-  - "/etc/prometheus/alert.rules.yml"
+  - "/etc/prometheus/alert.rules.yml" # Lista de arquivos de regras que o Prometheus irá carregar.
 
 scrape_configs:
-  - job_name: prometheus
+  - job_name: prometheus # Nome do job de scrape
     static_configs:
-    - targets: 
+    - targets:  # Prometheus coleta métricas dele mesmo, acessando o endpoint de métricas local.
         - 'localhost:9090'
 
-  - job_name: 'otel-collector'
-    scrape_interval: 5s
+  - job_name: 'otel-collector' # Nome do job para o OpenTelemetry Collector.
+    scrape_interval: 5s # Frequência de coleta para esse job é de 5 segundos (mais frequente que o global).
     static_configs:
-      - targets: ['otel-collector:8889']
+      - targets: ['otel-collector:8889'] # Prometheus coleta métricas do endpoint do otel-collector exposto na porta 8889 (conforme sua config anterior).
 
   - job_name: 'casoft-store-api-gateway'
     scheme: http
@@ -113,10 +113,18 @@ scrape_configs:
       - targets: 
          - 'node-exporter:9100'
 
+# Lista de endpoints do Alertmanager para onde o Prometheus enviará alertas.
 alerting:
   alertmanagers:
   - scheme: http
     static_configs:
       - targets: 
-          - 'alertmanager:9093'
-          
+          - 'alertmanager:9093' # O Alertmanager está disponível no endereço alertmanager:9093 (provavelmente outro container no mesmo ambiente).
+
+
+#Resumo:          
+# Prometheus coleta métricas dele mesmo e do otel-collector.
+# As regras de alerta estão em um arquivo externo.
+# Os alertas são enviados para um Alertmanager.
+# O otel-collector é monitorado com uma frequência maior (5s).
+# Configuração típica para um ambiente Docker Compose, Kubernetes ou testes locais.          

--- a/docker/configs/tempo.yaml
+++ b/docker/configs/tempo.yaml
@@ -1,0 +1,90 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+
+cache:
+  background:
+    writeback_goroutines: 5
+  caches:
+  - roles:
+    - frontend-search  
+    memcached: 
+      host: memcached:11211
+
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+    metadata_slo:
+        duration_slo: 5s
+        throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 100ms
+  metrics:
+    max_duration: 120h                # maximum duration of a metrics query, increase for local setups
+    query_backend_after: 5m
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+
+distributor:
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        thrift_http:                   #
+          endpoint: "tempo:14268"      # for a production deployment you should only enable the receivers you need!
+        grpc:
+          endpoint: "tempo:14250"
+        thrift_binary:
+          endpoint: "tempo:6832"
+        thrift_compact:
+          endpoint: "tempo:6831"
+    zipkin:
+      endpoint: "tempo:9411"
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "tempo:4317"
+        http:
+          endpoint: "tempo:4318"
+    opencensus:
+      endpoint: "tempo:55678"
+
+ingester:
+  max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+
+compactor:
+  compaction:
+    block_retention: 24h                # overall Tempo trace retention. set for demo purposes
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
+  processor:
+    local_blocks:
+      filter_server_spans: false
+      flush_to_storage: true
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    wal:
+      path: /var/tempo/wal             # where to store the wal locally
+    local:
+      path: /var/tempo/blocks
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics, local-blocks] # enables metrics generator
+      generate_native_histograms: both

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -383,7 +383,7 @@ services:
     restart: unless-stopped
 
   otel-collector:
-    image: otel/opentelemetry-collector:0.122.0
+    image: otel/opentelemetry-collector-contrib:0.122.0
     container_name: otel-collector
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
@@ -411,7 +411,6 @@ services:
     ports:
       - "16686:16686"
     restart: unless-stopped 
-
 
     
   # caso de erro sincronização time: https://stackoverflow.com/questions/42200734/how-to-re-synchronize-the-prometheus-time  
@@ -481,26 +480,49 @@ services:
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)'
       
   # alloy:
-    # image: grafana/alloy:v1.8.3
-    # container_name: alloy
-    # volumes:
-      # - ./configs/config.alloy:/etc/alloy/config.alloy
-      # - /var/run/docker.sock:/var/run/docker.sock
-    # environment:
-      # - GRAFANA_CLOUD_OTLP_ENDPOINT=https://otlp-gateway-prod-sa-east-1.grafana.net/otlp
-      # - GRAFANA_CLOUD_INSTANCE_ID=898019
-      # - GRAFANA_CLOUD_API_KEY=glc_eyJvIjoiMTA5MjU0MCIsIm4iOiJzdGFjay04OTgwMTktb3RlbC1vbmJvYXJkaW5nLWNhc29mdC1zeXN0ZW0iLCJrIjoiOTY1ZzFlS3RVMjV1dzA4eE91UU56NXEwIiwibSI6eyJyIjoicHJvZC1zYS1lYXN0LTEifX0%3D
+    # image: grafana/alloy:v1.7.5
     # ports:
-      # - "12345:12345"
-      # - "4317:4317"
-      # - "4318:4318"
-    # command:
-      # - run
-      # - --server.http.listen-addr=0.0.0.0:12345
-      # - --storage.path=/var/lib/alloy/data
-      # - /etc/alloy/config.alloy
+      # - 12345:12345
+      # - 4318:4318
+      # - 4317:4317
+    # volumes:
+      # - ./config.alloy:/etc/alloy/config.alloy
+    # command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    # depends_on:
+      # - loki
 
-     
+  # Tempo
+  # Tempo runs as user 10001, and docker compose creates the volume as root.
+  # As such, we need to chown the volume in order for Tempo to start correctly.
+  init:
+    image: &tempoImage grafana/tempo:2.7.1
+    user: root
+    entrypoint:
+      - "chown"
+      - "10001:10001"
+      - "/var/tempo"
+    volumes:
+      - ./tempo-data:/var/tempo
+
+  memcached:
+    image: memcached:1.6.29
+    container_name: memcached
+    ports:
+      - "11211:11211"
+    environment:
+      - MEMCACHED_MAX_MEMORY=64m  # Set the maximum memory usage
+      - MEMCACHED_THREADS=4       # Number of threads to use
+
+  tempo:
+    image: *tempoImage
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+    ports:
+      - "3200:3200"   # tempo
+    depends_on:
+      - init
+      - memcached     
 
 volumes:
   mongo_vol:

--- a/docker/k6-stress.js
+++ b/docker/k6-stress.js
@@ -1,0 +1,21 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+    vus: 200, // Número de usuários simultâneos
+    duration: '10m', // Tempo do teste
+};
+
+export default function () {
+    let params = {
+        headers: {
+            'Authorization': 'eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJHVlV0cHZ3ajdIRmI5WVNwVHZMY2F0dEM4YUpZU2J3bG1BQ0U3aFNLWHEwIn0.eyJleHAiOjE3NDI3MDM5OTksImlhdCI6MTc0MjY2Nzk5OSwianRpIjoiNjIxYmMxOGUtMDBhMi00Yzk1LWI0MDgtMTQ4OTc0NzcxMzhkIiwiaXNzIjoiaHR0cDovL2Nhc29mdC1zdG9yZS1rZXljbG9hazo4MDgwL3JlYWxtcy9jYXNvZnQiLCJhdWQiOlsiY2Fzb2Z0c3lzdGVtIiwiYWNjb3VudCJdLCJzdWIiOiI0NzM5MmI3Ny1mMDBmLTRhOGMtYTU3MC1iMWNlNWY1NTZlMjUiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJjYXNvZnRzeXN0ZW0iLCJzaWQiOiI3NWZmMDViOC01MzQ3LTRmZjAtYTE5OS00Yzg4ZWFiY2NjYmUiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbIioiXSwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbIm9mZmxpbmVfYWNjZXNzIiwiZGVmYXVsdC1yb2xlcy1jYXNvZnQiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImNhc29mdHN5c3RlbSI6eyJyb2xlcyI6WyJEZWxldGUiLCJSZWFkIiwiQ3JlYXRlIiwiQWRtaW4iLCJVcGRhdGUiXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsIm5hbWUiOiJDZXNhciBTYW50b3MiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJjZXNhciIsImdpdmVuX25hbWUiOiJDZXNhciIsImZhbWlseV9uYW1lIjoiU2FudG9zIiwiZW1haWwiOiJjZXNhckBkZW1vLmNvbSJ9.IVxEvJU8EaIHLFl0HM5hVLBPa0i64cpz1inuDRNjqNXG3NM94jE5r1qWzHjQbkH-gI21KAqV-j14hLR_S-i8n-hxq2dfyWFjLonLlhIFKDj1JiPnD3XvZeYHxn8ZZCODuoqtYcODCYW4615NCff4JEIwoHM4E_4aX94aKowkm1sw9fSZAYbPtcNnPjcJoc2WXCAvykdpVQZ_KkwvLIcuTDQqx0dsWLg0oJBTtUyKsfc8xtVKyTpY_MSMk9odyxjA9KPtuXyn8TcNisueKinDvFLeL8umGD5mRjlXPob4IUTpZb_VQSp8lmY2ybmPBik9SsuAGSdtWY5WN_SuLSqtFA',
+            'Content-Type': 'application/json'
+        }
+    };
+
+    let res = http.get('http://localhost:5256/api/product/all', params);
+    check(res, { 'status é 200': (r) => r.status === 200 });
+
+    sleep(1);
+}


### PR DESCRIPTION
- Updated `.gitignore` to include `*.env` files.
- Enhanced comments in `alert.rules.yml` and `alertmanager.yml` for clarity on alert conditions and routing.
- Restructured `config.alloy` with new logging and output settings, added `livedebugging`.
- Clarified configuration settings in `loki.yaml` and `otel-collector-config.yaml`.
- Updated `prometheus.yml` with comments on scrape intervals and alerting.
- Modified `docker-compose.yaml` to update OpenTelemetry Collector image and add `memcached` and `tempo` services.
- Added `k6-stress.js` for API load testing.
- Introduced `tempo.yaml` with comprehensive configuration for the Tempo service.